### PR TITLE
Refactoring DenseSparseArray for simpler accessing of components

### DIFF
--- a/include/ECS/DenseSparseArray.hpp
+++ b/include/ECS/DenseSparseArray.hpp
@@ -4,11 +4,12 @@
 
 #pragma once
 
-    #include <utility>
     #include <vector>
+    #include <print>
 
     #include "ECS/Entity.hpp"
     #include "ECS/SparseArray.hpp"
+    #include "SafeReference.hpp"
 
 namespace dng {
 
@@ -19,49 +20,71 @@ namespace dng {
 template <typename Component>
 class DenseSparseArray {
  public:
-    using value_type = Component;
+    using value_type = std::optional<Component>;
+    using reference_type = OptionalRef<Component>;
+    using const_reference_type = value_type const;
+    using size_type = typename dng::Entity;
+
+    using iterator = typename std::vector<size_type>::iterator;
+    using const_iterator = typename std::vector<size_type>::const_iterator;
 
     DenseSparseArray() = default;
+    DenseSparseArray(const DenseSparseArray& spa) = default;
+    DenseSparseArray(DenseSparseArray&& spa) noexcept = default;
+    ~DenseSparseArray() = default;
+
+    DenseSparseArray& operator=(const DenseSparseArray&) = default;
+    DenseSparseArray& operator=(DenseSparseArray&&) noexcept = default;
+
+    reference_type operator[](size_type idx) {
+        if (hasComponent(idx))
+            return _dense[_spar[PAGE(idx)][PAGE_INDEX(idx)].value()];
+        else
+            return std::nullopt;
+    }
+
+    const_reference_type operator[](size_type idx) const {
+        if (hasComponent(idx))
+            return _dense[_spar[PAGE(idx)][PAGE_INDEX(idx)].value()];
+        else
+            return std::nullopt;
+    }
 
     template <typename ...Args>
-    void createComponent(Entity e, Args&&... args) {
-        if (PAGE(e) >= _spar.size()) {
+    reference_type emplace_at(size_type e, Args&&... args) {
+        if (PAGE(e) >= _spar.size())
             _spar.resize(PAGE(e) + 1);
-        }
         _spar[PAGE(e)].insert_at(PAGE_INDEX(e), _dense.size());
         _dense.emplace_back(std::forward<Args>(args)...);
         _dense_to_entity.push_back(e);
+        return _dense[_spar[PAGE(e)][PAGE_INDEX(e)].value()];
     }
 
-    void addComponent(Entity e, Component&& cmpt) {
+    reference_type insert_at(size_type e, Component&& cmpt) {
         if (PAGE(e) >= _spar.size()) {
             _spar.resize(PAGE(e) + 1);
         }
         _spar[PAGE(e)].insert_at(PAGE_INDEX(e), _dense.size());
         _dense.push_back(std::forward<Component>(cmpt));
         _dense_to_entity.push_back(e);
+        return _dense[_spar[PAGE(e)][PAGE_INDEX(e)].value()];
     }
 
-    void addComponent(Entity e, const Component& cmpt) {
+    reference_type insert_at(size_type e, const Component& cmpt) {
         if (PAGE(e) >= _spar.size()) {
             _spar.resize(PAGE(e) + 1);
         }
         _spar[PAGE(e)].insert_at(PAGE_INDEX(e), _dense.size());
         _dense.push_back(cmpt);
         _dense_to_entity.push_back(e);
+        return _dense[_spar[PAGE(e)][PAGE_INDEX(e)].value()];
     }
 
-    bool hasComponent(Entity e) {
-        return (PAGE(e) < _spar.size() &&
-            PAGE_INDEX(e) <_spar[PAGE(e)].size() &&
-            _spar[PAGE(e)][PAGE_INDEX(e)].has_value());
-    }
-
-    void removeComponent(Entity e) {
+    void erase(size_type e) {
         if (!hasComponent(e))
             return;
         std::size_t del_index = _spar[PAGE(e)][PAGE_INDEX(e)].value();
-        Entity back_e = _dense_to_entity.back();
+        size_type back_e = _dense_to_entity.back();
         if (del_index != _dense.size() - 1) {
             std::swap(_dense[del_index], _dense.back());
             std::swap(_dense_to_entity[del_index], _dense_to_entity.back());
@@ -70,6 +93,14 @@ class DenseSparseArray {
         _spar[PAGE(e)][PAGE_INDEX(e)] = std::nullopt;
         _dense.pop_back();
         _dense_to_entity.pop_back();
+    }
+
+    size_type get_index(const_reference_type value) const {
+        auto i = std::find(_dense.begin(), _dense.end(), value);
+
+        if (hasComponent(_dense_to_entity[i]))
+            return _dense_to_entity[i];
+        return _spar.size() * MAX_PAGE_SIZE + _spar[_spar.size() - 1].size();
     }
 
     std::vector<SparseArray<std::size_t>>& getSpar() {
@@ -88,18 +119,24 @@ class DenseSparseArray {
         return _dense[idx];
     }
 
-    Component& getComponent(Entity e) {
+    Component& getComponent(size_type e) {
         return _dense[_spar[PAGE(e)][PAGE_INDEX(e)].value()];
     }
 
-    const Component& getComponent(Entity e) const {
+    const Component& getComponent(size_type e) const {
         return _dense[_spar[PAGE(e)][PAGE_INDEX(e)].value()];
     }
 
  private:
     std::vector<Component> _dense;
-    std::vector<Entity> _dense_to_entity;
-    std::vector<SparseArray<std::size_t>> _spar;
+    std::vector<size_type> _dense_to_entity;
+    std::vector<SparseArray<size_type>> _spar;
+
+    bool hasComponent(size_type e) {
+        return (PAGE(e) < _spar.size() &&
+            PAGE_INDEX(e) <_spar[PAGE(e)].size() &&
+            _spar[PAGE(e)][PAGE_INDEX(e)].has_value());
+    }
 };
 
 }  // namespace dng

--- a/include/ECS/Registry.hpp
+++ b/include/ECS/Registry.hpp
@@ -18,6 +18,7 @@
     #include "ECS/DenseSparseArray.hpp"
     #include "ECS/Entity.hpp"
     #include "ECS/SignalManager.hpp"
+    #include "ECS/SafeReference.hpp"
 
 namespace dng {
 
@@ -59,8 +60,7 @@ class TypeNotRegistred : public std::exception {
  * @tparam Component The component type (e.g., Position, Velocity)
  */
 template <typename Component>
-using SafeArray = std::expected<
-    std::reference_wrapper<DenseSparseArray<Component>>, TypeNotRegistred>;
+using SafeArray = ExpectRef<DenseSparseArray<Component>, TypeNotRegistred>;
 
 /**
  * @brief Type-erased storage for all component arrays
@@ -83,7 +83,7 @@ struct ComponentListStorer :
      *
      * @tparam Component The component type to retrieve
      * @return SafeArray<Component> containing either:
-     *         - reference_wrapper to the array (use .value().get())
+     *         - reference_wrapper to the array (use .value())
      *         - TypeNotRegistred error (check with .has_value())
      *
      * Example usage:
@@ -216,7 +216,7 @@ class Registry : public SignalManager {
                     components.error().what());
                 return;
             }
-            components.value().get().removeComponent(e);
+            components.value().erase(e);
         });
 
         return _components.getSparseArray<Component>();
@@ -312,7 +312,7 @@ class Registry : public SignalManager {
                 list.error().what());
             return;
         }
-        list.value().get().createComponent(e, std::forward<Args>(args)...);
+        list.value().emplace_at(e, std::forward<Args>(args)...);
     }
 
     /**
@@ -342,7 +342,7 @@ class Registry : public SignalManager {
                 list.error().what());
             return;
         }
-        list.value().get().addComponent(e, c);
+        list.value().insert_at(e, c);
 }
 
     /**
@@ -375,7 +375,7 @@ class Registry : public SignalManager {
                 list.error().what());
             return;
         }
-        list.value().get().addComponent(e, std::forward<Component>(c));
+        list.value().insert_at(e, std::forward<Component>(c));
     }
 
     /**
@@ -404,7 +404,7 @@ class Registry : public SignalManager {
                 list.error().what());
             return;
         }
-        list.value().get().removeComponent(e);
+        list.value().erase(e);
     }
 
  private:

--- a/include/ECS/Registry.hpp
+++ b/include/ECS/Registry.hpp
@@ -49,13 +49,13 @@ class TypeNotRegistred : public std::exception {
  * @brief Type alias for safe component array access
  *
  * Returns either:
- * - A reference_wrapper to the component array (success case)
+ * - A reference to the component array (success case)
  * - A TypeNotRegistred error (failure case)
  *
- * Why std::reference_wrapper?
- * - std::expected cannot hold reference types directly (std::expected<T&, E> is illegal)
- * - reference_wrapper allows us to safely return references in value semantics
- * - Call .get() on the wrapper to access the underlying array
+ * ExpectRef automatically unwraps references:
+ * - Access with .value() to get the array reference directly
+ * - Or use operator* for dereference: *result
+ * - No need to call .get() - unwrapping is automatic
  *
  * @tparam Component The component type (e.g., Position, Velocity)
  */
@@ -83,17 +83,23 @@ struct ComponentListStorer :
      *
      * @tparam Component The component type to retrieve
      * @return SafeArray<Component> containing either:
-     *         - reference_wrapper to the array (use .value())
+     *         - A reference to the array (access with .value() or *result)
      *         - TypeNotRegistred error (check with .has_value())
      *
      * Example usage:
      * @code{.cpp}
      * auto result = storer.getSparseArray<Position>();
      * if (result.has_value()) {
-     *     auto& array = result.value().get();  // Get actual array
+     *     auto& array = result.value();  // Direct access, no .get() needed
      *     // Use array...
      * } else {
      *     std::println("Error: {}", result.error().what());
+     * }
+     *
+     * // Alternative: use operator*
+     * if (result.has_value()) {
+     *     auto& array = *result;
+     *     // Use array...
      * }
      * @endcode
      */
@@ -152,7 +158,7 @@ struct ComponentListStorer :
  * // 3. Access components in a system
  * auto positions = reg.getComponents<Position>();
  * auto velocities = reg.getComponents<Velocity>();
- * if (positions && velocities) {
+ * if (positions.has_value() && velocities.has_value()) {
  *     for (auto&& [pos, vel] : Zipper(*positions, *velocities)) {
  *         pos.x += vel.x;  // Move entities
  *         pos.y += vel.y;

--- a/include/ECS/SafeReference.hpp
+++ b/include/ECS/SafeReference.hpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 <D&Gine Group>
+ */
+
+#pragma once
+
+    #include <expected>
+    #include <optional>
+    #include <functional>
+
+template <typename Object, typename Error>
+class ExpectRef : public std::expected<std::reference_wrapper<Object>, Error> {
+ private:
+    using Base = std::expected<std::reference_wrapper<Object>, Error>;
+
+ public:
+    ExpectRef() = default;
+    ExpectRef(std::unexpected<Error>&& val) : Base(std::move(val)) {}
+    ExpectRef(const std::unexpected<Error>& val) : Base(val) {}
+    ExpectRef(Object& obj) : Base(std::ref(obj)) {}
+
+    Object& operator*() { return Base::value().get(); }
+    const Object& operator*() const { return Base::value().get(); }
+
+    Object& value() { return Base::value().get(); }
+    const Object& value() const { return Base::value().get(); }
+
+    Object* operator->() { return &(Base::value().get()); }
+    const Object* operator->() const { return &(Base::value().get()); }
+};
+
+template <typename Object>
+class OptionalRef : public std::optional<std::reference_wrapper<Object>> {
+ private:
+    using Base = std::optional<std::reference_wrapper<Object>>;
+
+ public:
+    OptionalRef() = default;
+    OptionalRef(std::nullopt_t&& val) : Base(std::move(val)) {}
+    OptionalRef(const std::nullopt_t& val) : Base(val) {}
+    OptionalRef(Object& obj) : Base(std::ref(obj)) {}
+
+    Object& operator*() { return Base::value().get(); }
+    const Object& operator*() const { return Base::value().get(); }
+
+    Object& value() { return Base::value().get(); }
+    const Object& value() const { return Base::value().get(); }
+
+    Object* operator->() { return &(Base::value().get()); }
+    const Object* operator->() const { return &(Base::value().get()); }
+};

--- a/include/ECS/SafeReference.hpp
+++ b/include/ECS/SafeReference.hpp
@@ -8,6 +8,34 @@
     #include <optional>
     #include <functional>
 
+/**
+ * @brief std::expected wrapper that transparently holds a reference
+ *
+ * Inherits from std::expected<std::reference_wrapper<Object>, Error> and
+ * overrides operator*, value(), and operator-> to unwrap the reference
+ * automatically.
+ *
+ * @tparam Object The referenced object type
+ * @tparam Error  The error type returned on failure
+ *
+ * Example usage:
+ * @code{.cpp}
+ * ExpectRef<DenseSparseArray<Position>, TypeNotRegistred> getArray() {
+ *     if (!registered)
+ *         return std::unexpected(TypeNotRegistred("Position"));
+ *     return array;   // implicitly wraps the reference
+ * }
+ *
+ * auto result = getArray();
+ * if (result.has_value()) {
+ *     result->addComponent(entity, data);   // arrow operator
+ *     auto& arr = *result;                  // dereference operator
+ *     auto& arr = result.value();           // value() method
+ * } else {
+ *     std::println("error: {}", result.error().what());
+ * }
+ * @endcode
+ */
 template <typename Object, typename Error>
 class ExpectRef : public std::expected<std::reference_wrapper<Object>, Error> {
  private:
@@ -29,6 +57,33 @@ class ExpectRef : public std::expected<std::reference_wrapper<Object>, Error> {
     const Object* operator->() const { return &(Base::value().get()); }
 };
 
+/**
+ * @brief std::optional wrapper that transparently holds a reference
+ *
+ * Inherits from std::optional<std::reference_wrapper<Object>> and overrides
+ * operator*, value(), and operator-> to unwrap the reference automatically.
+ *
+ * Use this when you only need "present / absent" semantics and don't need
+ * an error value. For error details, use ExpectRef instead.
+ *
+ * @tparam Object The referenced object type
+ *
+ * Example usage:
+ * @code{.cpp}
+ * OptionalRef<std::string> findName(int id) {
+ *     auto it = names.find(id);
+ *     if (it == names.end())
+ *         return std::nullopt;
+ *     return it->second;   // implicitly wraps the reference
+ * }
+ *
+ * auto result = findName(42);
+ * if (result.has_value()) {
+ *     std::string& name = *result;    // dereference operator
+ *     result->clear();                // arrow operator
+ * }
+ * @endcode
+ */
 template <typename Object>
 class OptionalRef : public std::optional<std::reference_wrapper<Object>> {
  private:

--- a/include/ECS/Zipper.hpp
+++ b/include/ECS/Zipper.hpp
@@ -32,7 +32,7 @@ template <class... Containers>
 class Zipper {
  public:
     template <class... Cs>
-    class DenseZipIt {
+    class ZipperIterator {
      public:
         template <class Container>
         using unwrapped_t = unwrap_refwrapper_t<Container>;
@@ -46,18 +46,18 @@ class Zipper {
         using difference_type = std::ptrdiff_t;
         using iterator_category = std::forward_iterator_tag;
 
-        DenseZipIt(std::tuple<Cs...> containers, size_t page, size_t idx = 0) :
+        ZipperIterator(std::tuple<Cs...> containers, size_t page, size_t idx = 0) :
             _currents(containers), _page(page), _idx(idx), _is_end(false) {
             if (!_is_end && !all_set(_seq)) {
                 incr_all();
             }
         }
 
-        DenseZipIt& operator++() {
+        ZipperIterator& operator++() {
             incr_all();
             return *this;
         }
-        DenseZipIt operator++(int) {
+        ZipperIterator operator++(int) {
             auto prev = *this;
             ++(*this);
             return prev;
@@ -70,14 +70,14 @@ class Zipper {
             return to_value(_seq);
         }
 
-        friend bool operator==(const DenseZipIt& lhs,
-            const DenseZipIt& rhs) {
+        friend bool operator==(const ZipperIterator& lhs,
+            const ZipperIterator& rhs) {
                 return lhs._is_end == rhs._is_end &&
                     (lhs._is_end ||
                     (lhs._page == rhs._page && lhs._idx == rhs._idx));
         }
-        friend bool operator!=(const DenseZipIt& lhs,
-            const DenseZipIt& rhs) {
+        friend bool operator!=(const ZipperIterator& lhs,
+            const ZipperIterator& rhs) {
             return !(lhs == rhs);
         }
 
@@ -154,7 +154,7 @@ class Zipper {
         static constexpr std::index_sequence_for<Cs...> _seq{};
     };
 
-    using iterator = DenseZipIt<Containers...>;
+    using iterator = ZipperIterator<Containers...>;
 
     explicit Zipper(Containers... cs) :
         _currents(std::make_tuple(cs...)) {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,13 @@ int main() {
     if (!fake.has_value())
         std::println("Error: getting component: {}", fake.error().what());
 
+    auto val = positions.value()[0];
+    if (val.has_value()) {
+        std::println("HAS VAL: {}", val.value().x);
+    } else {
+        std::println("DON'T HAVE VAL");
+    }
+
     reg.createComponent<Position>(10, 1.f, 1.f);
     reg.createComponent<Velocity>(10, 1.f, 1.f);
 
@@ -63,9 +70,9 @@ int main() {
     reg.enableCallback(id_float);
     reg.emit<int>(3);
     reg.disableCallback(400);
-    for (auto&& [e, pos, vel] : dng::IndexedZipper(*positions, *velocities)) {
-        std::println("found [{}] {}-{} and {}-{}",
-            e, pos.x, pos.y, vel.x, vel.y);
-    }
+    // for (auto&& [e, pos, vel] : dng::IndexedZipper(*positions, *velocities)) {
+    //     std::println("found [{}] {}-{} and {}-{}",
+    //         e, pos.x, pos.y, vel.x, vel.y);
+    // }
     return 0;
 }


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/D-Gine/.github/blob/main/docs/CONTRIBUTING.md) and [Code of Conduct](https://github.com/D-Gine/.github/blob/main/docs/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

The goal was to create a simpler usage of DenseSparseArray:

Before
```c++
auto integers = reg.getComponents<int>();
if (integers.value().get().getSpar()[0][0].has_value()) {
     dng::Entity val = integers.value().get().getSpar()[0][0].value(); 
     auto& component = integers.value().get().getComponent(val);
}
```
After
```c++
auto integers = reg.getComponents<int>();
auto val = integers.value()[0];
if (val) {
    // do something
}
```

I did also a second simple update to get the code simpler:

Before
```c++
auto positions = reg.getComponents<Position>();
if (positions.has_value()) {
    // do something with positions.value().get()
}
```
After
```c++
auto positions = reg.getComponents<Position>();
if (positions.has_value()) {
    // do something with positions.value()
}
``
---

Fixes #22
